### PR TITLE
Add `orchard` as CLI alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Interactive TUI for managing git worktrees, PR status, and tmux sessions",
   "type": "module",
   "bin": {
-    "git-orchard": "dist/cli.js"
+    "git-orchard": "dist/cli.js",
+    "orchard": "dist/cli.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary
- Adds `orchard` as an additional bin entry in package.json so users can invoke the tool as just `orchard` instead of requiring the `git-` prefix

## Test plan
- [ ] `npm install -g git-orchard` registers both `git-orchard` and `orchard` commands
- [ ] Both commands resolve to the same `dist/cli.js` entrypoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)